### PR TITLE
Compile fix for macOS

### DIFF
--- a/inc/goldfish/common.h
+++ b/inc/goldfish/common.h
@@ -8,6 +8,11 @@
 #define bswap_16(x) _byteswap_ushort(x)
 #define bswap_32(x) _byteswap_ulong(x)
 #define bswap_64(x) _byteswap_uint64(x)
+#elif __APPLE__
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
 #else
 #include <byteswap.h>
 #endif


### PR DESCRIPTION
Hey @fschoenm ,

i discovered your fork of GoldFish and added a compilation fix for macOS.
Hopefully, you find this interesting.

Btw. which branch shall i actually use? There is `master` and `feature/clang-tidy`. Both of them seem to work for me. Are you planning to integrate the `clang-tidy` back to master?

Thanks already!