### PR TITLE
Another compilation fix for macOS

### DIFF
--- a/inc/goldfish/array_ref.h
+++ b/inc/goldfish/array_ref.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cassert>
 #include <iterator>
+#include <string_view>
 #include <vector>
 #include <version>
 

--- a/inc/goldfish/stream.h
+++ b/inc/goldfish/stream.h
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <array>
+#include <string>
 #include <vector>
 #include "array_ref.h"
 #include "common.h"


### PR DESCRIPTION
Hi @fschoenm,

this is another compilation fix for macOS. Reading JSONs and encoding CBORs are now working for me.
